### PR TITLE
#11 feat: Swagger 설정 추가

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.7.0'
+
 }
 
 dependencyManagement {

--- a/gateway/src/main/java/com/fn/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/fn/gateway/GatewayApplication.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.gateway;
+package com.fn.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
         - id: user-service
           uri: lb://user-service
           predicates:
-            - Path=/api/users/**, Path=/api/auth/**
+            - Path=/api/users/**, /api/auth/**, /user-service/**
           filters:
             - RewritePath=/user-service/(?<segment>.*), /$\{segment}
 
@@ -21,7 +21,7 @@ spring:
         - id: order-service
           uri: lb://order-service
           predicates:
-            - Path=/api/orders/**
+            - Path=/api/orders/**, /order-service/**
           filters:
             - RewritePath=/order-service/(?<segment>.*), /$\{segment}
 
@@ -29,7 +29,7 @@ spring:
         - id: product-service
           uri: lb://product-service
           predicates:
-            - Path=/api/products/**
+            - Path=/api/products/**, /product-service/**
           filters:
             - RewritePath=/product-service/(?<segment>.*), /$\{segment}
 
@@ -37,7 +37,7 @@ spring:
         - id: hub-service
           uri: lb://hub-service
           predicates:
-            - Path=/api/hubs/**
+            - Path=/api/hubs/**, /hub-service/**
           filters:
             - RewritePath=/hub-service/(?<segment>.*), /$\{segment}
 
@@ -45,7 +45,7 @@ spring:
         - id: company-service
           uri: lb://company-service
           predicates:
-            - Path=/api/companies/**
+            - Path=/api/companies/**, /company-service/**
           filters:
             - RewritePath=/company-service/(?<segment>.*), /$\{segment}
 
@@ -53,7 +53,7 @@ spring:
         - id: delivery-service
           uri: lb://delivery-service
           predicates:
-            - Path=/api/deliveries/**, /api/delivery-routes/**, /api/hub-to-hubs/**
+            - Path=/api/deliveries/**, /api/delivery-routes/**, /api/hub-to-hubs/**, /delivery-service/**
           filters:
             - RewritePath=/delivery-service/(?<segment>.*), /$\{segment}
 
@@ -61,7 +61,7 @@ spring:
         - id: delivery-manager-service
           uri: lb://delivery-manager-service
           predicates:
-            - Path=/api/delivery-managers/**
+            - Path=/api/delivery-managers/**, /delivery-manager-service/**
           filters:
             - RewritePath=/delivery-manager-service/(?<segment>.*), /$\{segment}
 
@@ -69,7 +69,7 @@ spring:
         - id: slack-service
           uri: lb://slack-service
           predicates:
-            - Path=/api/slack/**, /api/ai/**
+            - Path=/api/slack/**, /api/ai/**, /slack-service/**
           filters:
             - RewritePath=/slack-service/(?<segment>.*), /$\{segment}
 
@@ -81,3 +81,24 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui/index.html
+    urls:
+      - name: user-service
+        url: /user-service/v3/api-docs
+      - name: order-service
+        url: /order-service/v3/api-docs
+      - name: product-service
+        url: /product-service/v3/api-docs
+      - name: hub-service
+        url: /hub-service/v3/api-docs
+      - name: company-service
+        url: /company-service/v3/api-docs
+      - name: delivery-service
+        url: /delivery-service/v3/api-docs
+      - name: delivery-manager-service
+        url: /delivery-manager-service/v3/api-docs
+      - name: slack-service
+        url: /slack-service/v3/api-docs

--- a/gateway/src/test/java/com/fn/gateway/GatewayApplicationTests.java
+++ b/gateway/src/test/java/com/fn/gateway/GatewayApplicationTests.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.gateway;
+package com.fn.gateway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
- 모든 서비스에 Swagger 설정 적용

## 변경 타입  
- [x] 신규 기능 추가/수정  
- [ ] 버그 수정  
- [ ] 리팩토링  
- [x] 설정  
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)  

## 변경 내용  

### **as-is**  
- Swagger 미적용으로 API 문서 자동 생성 기능 없음  

### **to-be**  
- 모든 서비스(user, order, product, hub, company, delivery, delivery-manager, slack)에 Swagger 설정 추가  
- `/swagger-ui/index.html` 경로에서 API 문서 확인 가능  
- 각 서비스에 다음 의존성을 추가하면 Swagger 사용 가능:  

  ```gradle  
  implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.7.0'  
  ```  

## 코멘트  
- 추후 JWT 토큰 인증 기능을 추가할 예정  
- MVP 개발 완료 후, RestDocs도 적용할 예정