### PR TITLE
feat/#25_로그인 기능 구현

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -22,6 +22,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 ext {

--- a/gateway/src/main/java/com/fn/gateway/filter/AuthenticationFilter.java
+++ b/gateway/src/main/java/com/fn/gateway/filter/AuthenticationFilter.java
@@ -1,0 +1,78 @@
+package com.fn.gateway.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.fn.gateway.util.JwtUtil;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter implements GlobalFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(AuthenticationFilter.class);
+	private final JwtUtil jwtUtil;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		// 1) 경로 및 메서드 확인
+		String path = exchange.getRequest().getURI().getPath();
+		String method = exchange.getRequest().getMethod().name();
+		log.info("🔍 요청된 URI: {} {}", method, path);
+
+		// 2) 인증 예외 경로 -> 필터 스킵
+		if (isAllowedPath(path, method)) {
+			log.info("✅ 인증 예외 경로 - 필터 통과: {}", path);
+			return chain.filter(exchange);
+		}
+
+		// 3) 헤더에서 JWT 추출
+		String token = jwtUtil.extractToken(exchange);
+		log.info("🔍 JWT 추출 결과: {}", token != null ? "토큰 존재 ✅" : "토큰 없음 ❌");
+
+		// 4) JWT 검증 실패 시 401 반환
+		if (token == null || !jwtUtil.validateToken(token)) {
+			log.warn("🚨 인증 실패 - JWT 없음 또는 유효하지 않음");
+			exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+			return exchange.getResponse().setComplete();
+		}
+
+		// 5) Claims(유저 정보) 추출
+		Claims claims = jwtUtil.parseClaims(token);
+		String userId = claims.get("userId", String.class);
+		String userName = claims.get("userName", String.class);
+		String role = claims.get("role", String.class);
+		log.info("🔍 Claims 정보 - userId: {}, userName: {}, role: {}", userId, userName, role);
+
+		// 6) 내부 서비스로 전달할 사용자 정보 헤더에 추가 (exchange 객체 갱신)
+		exchange = exchange.mutate()
+			.request(exchange.getRequest().mutate()
+				.header("X-User-Id", userId)
+				.header("X-User-Name", userName)
+				.header("X-User-Role", role)
+				.build())
+			.build();
+
+		// ✅ 헤더가 추가되었는지 확인하는 로그
+		log.info("✅ 인증 완료, 헤더 추가 - X-User-Id: {}, X-User-Role: {}", userId, role);
+		log.info("🔍 최종 요청 헤더 목록: {}", exchange.getRequest().getHeaders());
+
+		return chain.filter(exchange);
+
+	}
+
+	// 인증 없이 통과시킬 경로
+	private boolean isAllowedPath(String path, String method) {
+		return path.startsWith("/api/auth/") ||  // 로그인/회원가입 API
+			path.startsWith("/swagger-ui") || // Swagger UI
+			path.startsWith("/v3/api-docs"); // Swagger API Docs
+	}
+}

--- a/gateway/src/main/java/com/fn/gateway/filter/AuthenticationFilter.java
+++ b/gateway/src/main/java/com/fn/gateway/filter/AuthenticationFilter.java
@@ -26,21 +26,17 @@ public class AuthenticationFilter implements GlobalFilter {
 		// 1) 경로 및 메서드 확인
 		String path = exchange.getRequest().getURI().getPath();
 		String method = exchange.getRequest().getMethod().name();
-		log.info("🔍 요청된 URI: {} {}", method, path);
 
 		// 2) 인증 예외 경로 -> 필터 스킵
 		if (isAllowedPath(path, method)) {
-			log.info("✅ 인증 예외 경로 - 필터 통과: {}", path);
 			return chain.filter(exchange);
 		}
 
 		// 3) 헤더에서 JWT 추출
 		String token = jwtUtil.extractToken(exchange);
-		log.info("🔍 JWT 추출 결과: {}", token != null ? "토큰 존재 ✅" : "토큰 없음 ❌");
 
 		// 4) JWT 검증 실패 시 401 반환
 		if (token == null || !jwtUtil.validateToken(token)) {
-			log.warn("🚨 인증 실패 - JWT 없음 또는 유효하지 않음");
 			exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
 			return exchange.getResponse().setComplete();
 		}
@@ -50,7 +46,6 @@ public class AuthenticationFilter implements GlobalFilter {
 		String userId = claims.get("userId", String.class);
 		String userName = claims.get("userName", String.class);
 		String role = claims.get("role", String.class);
-		log.info("🔍 Claims 정보 - userId: {}, userName: {}, role: {}", userId, userName, role);
 
 		// 6) 내부 서비스로 전달할 사용자 정보 헤더에 추가 (exchange 객체 갱신)
 		exchange = exchange.mutate()
@@ -60,10 +55,6 @@ public class AuthenticationFilter implements GlobalFilter {
 				.header("X-User-Role", role)
 				.build())
 			.build();
-
-		// ✅ 헤더가 추가되었는지 확인하는 로그
-		log.info("✅ 인증 완료, 헤더 추가 - X-User-Id: {}, X-User-Role: {}", userId, role);
-		log.info("🔍 최종 요청 헤더 목록: {}", exchange.getRequest().getHeaders());
 
 		return chain.filter(exchange);
 

--- a/gateway/src/main/java/com/fn/gateway/util/JwtUtil.java
+++ b/gateway/src/main/java/com/fn/gateway/util/JwtUtil.java
@@ -1,0 +1,59 @@
+package com.fn.gateway.util;
+
+import java.security.Key;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.ws.rs.core.HttpHeaders;
+
+@Component
+public class JwtUtil {
+	// "my-secret-key" 대신 Base64 인코딩된 키를 주입받을 수도 있음
+	@Value("${service.jwt.secret-key}")
+	private String secretKey;
+
+	private Key key;
+
+	@PostConstruct
+	public void init() {
+		byte[] decoded = Base64.getDecoder().decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(decoded);
+	}
+
+	// "Bearer " 제거 + 토큰 추출
+	public String extractToken(ServerWebExchange exchange) {
+		String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+			return null;
+		}
+		return authHeader.substring(7);
+	}
+
+	// 토큰 유효성 검사
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (JwtException e) {
+			return false;
+		}
+	}
+
+	// Claims(유저 정보) 파싱
+	public Claims parseClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+}
+

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
     web-application-type: reactive  # 리액티브 웹 애플리케이션 설정
   application:
     name: gateway-service  # 서비스명
+  config:
+    import:
+      - file:gateway/.env[.properties]
   cloud:
     gateway:
       routes:
@@ -102,3 +105,7 @@ springdoc:
         url: /delivery-manager-service/v3/api-docs
       - name: slack-service
         url: /slack-service/v3/api-docs
+
+service:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'fifteen-night-backend-develop'
 
-include 'common', 'gateway', 'server', 'company', 'hub-service'
+include 'common', 'gateway', 'server', 'company', 'hub-service', 'user'

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 ext {

--- a/user/src/main/java/com/fn/eureka/client/user/application/dto/auth/request/UserSignInRequestDto.java
+++ b/user/src/main/java/com/fn/eureka/client/user/application/dto/auth/request/UserSignInRequestDto.java
@@ -1,0 +1,11 @@
+package com.fn.eureka.client.user.application.dto.auth.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSignInRequestDto {
+	private String userName;
+	private String userPassword;
+}

--- a/user/src/main/java/com/fn/eureka/client/user/application/dto/auth/response/UserSignInResponseDto.java
+++ b/user/src/main/java/com/fn/eureka/client/user/application/dto/auth/response/UserSignInResponseDto.java
@@ -1,0 +1,11 @@
+package com.fn.eureka.client.user.application.dto.auth.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSignInResponseDto {
+	private String accessToken;
+	private String refreshToken;
+}

--- a/user/src/main/java/com/fn/eureka/client/user/application/exception/CustomJwtException.java
+++ b/user/src/main/java/com/fn/eureka/client/user/application/exception/CustomJwtException.java
@@ -1,0 +1,7 @@
+package com.fn.eureka.client.user.application.exception;
+
+public class CustomJwtException extends RuntimeException {
+	public CustomJwtException(String message) {
+		super(message);
+	}
+}

--- a/user/src/main/java/com/fn/eureka/client/user/application/exception/ErrorMessage.java
+++ b/user/src/main/java/com/fn/eureka/client/user/application/exception/ErrorMessage.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorMessage {
 	DUPLICATED_EMAIL("이미 가입된 이메일입니다."),
 	DUPLICATED_NICKNAME("이미 사용 중인 닉네임입니다."),
-	INVALID_PASSWORD("비밀번호가 유효하지 않습니다.");
+	WRONG_USERNAME_OR_PASSWORD("아이디 또는 비밀번호가 틀렸습니다.");
 
 	private final String message;
 }

--- a/user/src/main/java/com/fn/eureka/client/user/application/exception/JwtExceptionMessage.java
+++ b/user/src/main/java/com/fn/eureka/client/user/application/exception/JwtExceptionMessage.java
@@ -1,0 +1,15 @@
+package com.fn.eureka.client.user.application.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtExceptionMessage {
+	INVALID_JWT_SIGNATURE("잘못된 JWT 서명입니다."),
+	EXPIRED_JWT_TOKEN("만료된 JWT 토큰입니다."),
+	UNSUPPORTED_JWT_TOKEN("지원되지 않는 JWT 토큰입니다."),
+	JWT_CLAIM_IS_EMPTY("JWT 토큰이 비어있습니다.");
+
+	private final String message;
+}

--- a/user/src/main/java/com/fn/eureka/client/user/application/service/AuthService.java
+++ b/user/src/main/java/com/fn/eureka/client/user/application/service/AuthService.java
@@ -4,11 +4,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fn.eureka.client.user.application.dto.auth.request.UserSignInRequestDto;
 import com.fn.eureka.client.user.application.dto.auth.request.UserSignUpRequestDto;
+import com.fn.eureka.client.user.application.dto.auth.response.UserSignInResponseDto;
 import com.fn.eureka.client.user.application.dto.auth.response.UserSignUpResponseDto;
 import com.fn.eureka.client.user.application.exception.ErrorMessage;
 import com.fn.eureka.client.user.domain.entity.User;
 import com.fn.eureka.client.user.domain.repository.UserRepository;
+import com.fn.eureka.client.user.libs.util.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +21,7 @@ public class AuthService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
 
 	@Transactional
 	public UserSignUpResponseDto signUp(UserSignUpRequestDto requestDto) {
@@ -54,4 +58,23 @@ public class AuthService {
 			.userRole(user.getUserRole())
 			.build();
 	}
+
+	@Transactional(readOnly = true)
+	public UserSignInResponseDto signIn(UserSignInRequestDto requestDto) {
+		// 유저네임으로 유저 조회 후, 비밀번호 검증까지 한 번에 처리
+		User user = userRepository.findByUserName(requestDto.getUserName())
+			.filter(u -> passwordEncoder.matches(requestDto.getUserPassword(), u.getUserPassword()))
+			.orElseThrow(() -> new IllegalArgumentException(ErrorMessage.WRONG_USERNAME_OR_PASSWORD.getMessage()));
+
+		// Access/Refresh Token 발급
+		String accessToken = jwtUtil.createAccessToken(user.getUserId(), user.getUserName(), user.getUserRole());
+		String refreshToken = jwtUtil.createRefreshToken(user.getUserId());
+
+		// 로그인 성공 응답 DTO 반환
+		return UserSignInResponseDto.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
 }

--- a/user/src/main/java/com/fn/eureka/client/user/domain/repository/UserRepository.java
+++ b/user/src/main/java/com/fn/eureka/client/user/domain/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 	Optional<User> findByUserEmail(String userEmail);
 
 	Optional<User> findByUserNickname(String userNickname);
+
+	Optional<User> findByUserName(String userName);
 }

--- a/user/src/main/java/com/fn/eureka/client/user/infrastructure/filter/AuthenticationFilter.java
+++ b/user/src/main/java/com/fn/eureka/client/user/infrastructure/filter/AuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.fn.eureka.client.user.infrastructure.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fn.eureka.client.user.infrastructure.security.RequestUserDetails;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(AuthenticationFilter.class);
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		String requestUri = request.getRequestURI();
+		log.info("현재 요청 URI: {}", requestUri);
+
+		// 인증 예외 경로
+		if (requestUri.startsWith("/api/auth/") ||
+			requestUri.startsWith("/swagger-ui/") ||
+			requestUri.startsWith("/v3/api-docs"))
+		{
+			log.info("인증 예외 경로 - 필터 통과: {}", requestUri);
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		log.info("인증 필터 적용: {}", requestUri);
+
+		// API Gateway에서 전달된 인증 정보 추출
+		String userId = request.getHeader("X-User-Id");
+		String userName = request.getHeader("X-User-Name");
+		String role = request.getHeader("X-User-Role");
+
+
+		// ROLE_ 접두사 추가
+		if (!role.startsWith("ROLE_")) {
+			role = "ROLE_" + role;
+		}
+
+		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+		UserDetails userDetails = new RequestUserDetails(userId, userName, authorities);
+
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		log.info("인증 성공 - SecurityContext에 저장됨");
+
+		filterChain.doFilter(request, response);
+	}
+
+}

--- a/user/src/main/java/com/fn/eureka/client/user/infrastructure/security/RequestUserDetails.java
+++ b/user/src/main/java/com/fn/eureka/client/user/infrastructure/security/RequestUserDetails.java
@@ -1,0 +1,62 @@
+package com.fn.eureka.client.user.infrastructure.security;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class RequestUserDetails implements UserDetails {
+
+	private final String userId;
+	private final String userName;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public RequestUserDetails(String userId, String userName, Collection<? extends GrantedAuthority> authorities) {
+		this.userId = userId;
+		this.userName = userName;
+		this.authorities = authorities;
+	}
+
+	public String getUserId() {
+		return userId;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return null; // Gateway에서 인증하므로 비밀번호 필요 없음
+	}
+
+	@Override
+	public String getUsername() {
+		return userName;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/user/src/main/java/com/fn/eureka/client/user/infrastructure/security/SecurityConfig.java
+++ b/user/src/main/java/com/fn/eureka/client/user/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.fn.eureka.client.user.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.fn.eureka.client.user.infrastructure.filter.AuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final AuthenticationFilter authenticationFilter;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+}

--- a/user/src/main/java/com/fn/eureka/client/user/libs/util/JwtUtil.java
+++ b/user/src/main/java/com/fn/eureka/client/user/libs/util/JwtUtil.java
@@ -1,0 +1,92 @@
+package com.fn.eureka.client.user.libs.util;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fn.eureka.client.user.application.exception.CustomJwtException;
+import com.fn.eureka.client.user.application.exception.JwtExceptionMessage;
+import com.fn.eureka.client.user.domain.entity.UserRole;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class JwtUtil {
+	// Token 식별자
+	public static final String BEARER_PREFIX = "Bearer ";
+	// 토큰 만료시간
+	@Value("${service.jwt.access-expiration}")
+	private long ACCESS_TOKEN_TIME;
+
+	@Value("${service.jwt.refresh-expiration}")
+	private long REFRESH_TOKEN_TIME;
+
+	@Value("${service.jwt.secret-key}")
+	private String secretKey;
+	private Key key;
+
+	@PostConstruct
+	public void init() {
+		byte[] bytes = Base64.getDecoder().decode(secretKey);
+		key = Keys.hmacShaKeyFor(bytes);
+	}
+
+	public String createAccessToken(UUID userId, String userName, UserRole userRole) {
+		Date date = new Date();
+
+		return BEARER_PREFIX +
+			Jwts.builder()
+				.claim("userId", userId.toString()) // 사용자 식별자값(userId)
+				.claim("userName", userName)
+				.claim("role", userRole)
+				.setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME)) // 만료 시간
+				.setIssuedAt(date) // 발급일
+				.signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘
+				.compact();
+	}
+
+	public String createRefreshToken(UUID userId) {
+		Date date = new Date();
+
+		return Jwts.builder()
+			.claim("userId", userId.toString())
+			.setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME)) // 만료 시간
+			.setIssuedAt(date) // 발급일
+			.signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘
+			.compact();
+	}
+
+	public Claims parseClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+	public void validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+		} catch (SecurityException | MalformedJwtException | SignatureException e) {
+			throw new CustomJwtException(JwtExceptionMessage.INVALID_JWT_SIGNATURE.getMessage());
+		} catch (ExpiredJwtException e) {
+			throw new CustomJwtException(JwtExceptionMessage.EXPIRED_JWT_TOKEN.getMessage());
+		} catch (UnsupportedJwtException e) {
+			throw new CustomJwtException(JwtExceptionMessage.UNSUPPORTED_JWT_TOKEN.getMessage());
+		} catch (IllegalArgumentException e) {
+			throw new CustomJwtException(JwtExceptionMessage.JWT_CLAIM_IS_EMPTY.getMessage());
+		}
+	}
+}

--- a/user/src/main/java/com/fn/eureka/client/user/presentation/controller/AuthController.java
+++ b/user/src/main/java/com/fn/eureka/client/user/presentation/controller/AuthController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fn.eureka.client.user.application.dto.ApiResponseDto;
+import com.fn.eureka.client.user.application.dto.auth.request.UserSignInRequestDto;
 import com.fn.eureka.client.user.application.dto.auth.request.UserSignUpRequestDto;
+import com.fn.eureka.client.user.application.dto.auth.response.UserSignInResponseDto;
 import com.fn.eureka.client.user.application.dto.auth.response.UserSignUpResponseDto;
 import com.fn.eureka.client.user.application.service.AuthService;
 
@@ -27,5 +29,13 @@ public class AuthController {
 
 		return ResponseEntity.ok(ApiResponseDto.success(responseDto));
 	}
+
+	@PostMapping("/signIn")
+	public ResponseEntity<ApiResponseDto<UserSignInResponseDto>> signIn(@RequestBody UserSignInRequestDto requestDto) {
+		UserSignInResponseDto responseDto = authService.signIn(requestDto);
+
+		return ResponseEntity.ok(ApiResponseDto.success(responseDto));
+	}
+
 }
 

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -21,6 +21,13 @@ spring:
       hibernate:
         format_sql: true  # SQL 보기 좋게 출력
 
+service:
+  jwt:
+    access-expiration: ${JWT_ACCESS_EXPIRATION}
+    refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+    secret-key: ${JWT_SECRET_KEY}
+
+
 server:
   port: ${SERVER_PORT}  # 서버 포트 환경변수로 설정
 


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**
    - 로그인 요청 처리 기능 추가
    - 로그인 요청 DTO 생성
    - JWT 기반 인증 로직 구현
    - 로그인 성공 시 액세스/리프레시 토큰 발급
    - 로그인 실패 시 메시지 처리

## 코멘트
- 로그인 완료 시 토큰이 생성되는데 Bearer을 제외하고 복사
![스크린샷 2025-03-17 오후 5 06 05](https://github.com/user-attachments/assets/3963ae07-d1c2-483b-8005-f53022343921)
- 포스트맨의 경우 이런식으로 입력
![스크린샷 2025-03-17 오후 5 05 52](https://github.com/user-attachments/assets/d6e0533c-669c-45d7-9d66-883c8c9b704f)
- 유저정보는 @AuthenticationPrincipal RequestUserDetails userDetails 이런식으로 가져와서 사용 가능합니다
![스크린샷 2025-03-17 오후 5 07 12](https://github.com/user-attachments/assets/a69f3a44-92f6-4587-9a46-fa37615f299e)


