### PR TITLE
#63 feat: slack - 메시지 조회 기능 구현

### DIFF
--- a/common/src/main/java/com/fn/common/global/success/SuccessCode.java
+++ b/common/src/main/java/com/fn/common/global/success/SuccessCode.java
@@ -31,6 +31,11 @@ public enum SuccessCode {
 	USER_LIST_FOUND(HttpStatus.OK, "사용자 목록이 성공적으로 조회되었습니다.", "S_USER_LIST_FOUND"),
 	USER_UPDATED(HttpStatus.OK, "사용자 정보가 성공적으로 수정되었습니다.", "S_USER_UPDATED"),
 	USER_DELETED(HttpStatus.OK, "사용자 정보가 성공적으로 삭제되었습니다.", "S_USER_DELETED"),
+
+	// Slack 관련 성공 응답
+	SLACK_MESSAGE_SENT(HttpStatus.CREATED, "Slack 메시지가 성공적으로 전송되었습니다.", "S_SLACK_MESSAGE_SENT"),
+	SLACK_MESSAGE_FOUND(HttpStatus.OK, "Slack 메시지가 성공적으로 조회되었습니다.", "S_SLACK_MESSAGE_FOUND"),
+	SLACK_MESSAGE_LIST_FOUND(HttpStatus.OK, "Slack 메시지 목록이 성공적으로 조회되었습니다.", "S_SLACK_MESSAGE_LIST_FOUND")
 	;
 
 	private final HttpStatus statusCode;

--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -31,9 +31,6 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
-
-	implementation("com.slack.api:slack-api-client:1.45.3")
-
 }
 
 ext {

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/dto/response/SlackGetResponseDto.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/dto/response/SlackGetResponseDto.java
@@ -1,0 +1,15 @@
+package com.fn.eureka.client.slackservice.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SlackGetResponseDto {
+	private UUID slackId;
+	private String receiverId;
+	private String message;
+	private LocalDateTime sentAt;
+}

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/exception/SlackException.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/exception/SlackException.java
@@ -1,0 +1,36 @@
+package com.fn.eureka.client.slackservice.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.fn.common.global.exception.type.ExceptionType;
+
+public enum SlackException implements ExceptionType {
+
+	SLACK_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "Slack 메시지를 찾을 수 없습니다.", "E_SLACK_MESSAGE_NOT_FOUND"),
+	UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "마스터 권한이 필요합니다.", "E_UNAUTHORIZED_ACCESS");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String errorCode;
+
+	SlackException(HttpStatus httpStatus, String message, String errorCode) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+		this.errorCode = errorCode;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return this.httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.message;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return this.errorCode;
+	}
+}

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/service/SlackService.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/service/SlackService.java
@@ -1,17 +1,28 @@
 package com.fn.eureka.client.slackservice.application.service;
 
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import com.fn.common.global.dto.CommonResponse;
+import com.fn.common.global.success.SuccessCode;
 import com.fn.eureka.client.slackservice.application.dto.request.SlackMessageRequestDto;
+import com.fn.eureka.client.slackservice.application.dto.response.SlackGetResponseDto;
 import com.fn.eureka.client.slackservice.application.dto.response.SlackMessageResponseDto;
+import com.fn.eureka.client.slackservice.application.exception.SlackException;
 import com.fn.eureka.client.slackservice.domain.entity.Slack;
 import com.fn.eureka.client.slackservice.domain.repository.SlackRepository;
+import com.fn.eureka.client.slackservice.infrastructure.security.RequestUserDetails;
+import com.fn.common.global.exception.CustomApiException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,11 +33,11 @@ public class SlackService {
 	@Value("${slack.webhook.url}")
 	private String slackWebhookUrl;
 
-	private final RestTemplate restTemplate; // RestTemplate 사용
-	private final SlackRepository slackRepository; // DB 저장을 위한 JPA Repository
+	private final RestTemplate restTemplate;
+	private final SlackRepository slackRepository;
 
 	@Transactional
-	public SlackMessageResponseDto sendSlackMessage(SlackMessageRequestDto requestDto) {
+	public CommonResponse<SlackMessageResponseDto> sendSlackMessage(SlackMessageRequestDto requestDto) {
 		// Slack Webhook 요청 보내기
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
@@ -38,8 +49,65 @@ public class SlackService {
 		Slack slackMessage = Slack.of(requestDto.getSlackReceiverId(), requestDto.getText());
 		slackRepository.save(slackMessage);
 
-		return SlackMessageResponseDto.builder()
+		SlackMessageResponseDto responseDto = SlackMessageResponseDto.builder()
 			.slackId(slackMessage.getSlackId())
 			.build();
+
+		return new CommonResponse<>(SuccessCode.SLACK_MESSAGE_SENT, responseDto);
+	}
+
+	@Transactional(readOnly = true)
+	public CommonResponse<SlackGetResponseDto> getSlackMessage(UUID slackId) {
+		validateMasterRole();
+
+		Slack slackMessage = slackRepository.findById(slackId)
+			.orElseThrow(() -> new CustomApiException(SlackException.SLACK_MESSAGE_NOT_FOUND));
+
+		SlackGetResponseDto responseDto = SlackGetResponseDto.builder()
+			.slackId(slackMessage.getSlackId())
+			.receiverId(slackMessage.getSlackReceiverId())
+			.message(slackMessage.getSlackMessage())
+			.sentAt(slackMessage.getCreatedAt())
+			.build();
+
+		return new CommonResponse<>(SuccessCode.SLACK_MESSAGE_FOUND, responseDto);
+	}
+
+	@Transactional(readOnly = true)
+	public CommonResponse<Page<SlackGetResponseDto>> getSlackMessages(String keyword, Pageable pageable) {
+		validateMasterRole();
+
+		Page<Slack> messages = (keyword == null || keyword.trim().isEmpty()) ?
+			slackRepository.findAll(pageable) :
+			slackRepository.findByKeyword(keyword, pageable);
+
+		Page<SlackGetResponseDto> responseDtoPage = messages.map(slack -> SlackGetResponseDto.builder()
+			.slackId(slack.getSlackId())
+			.receiverId(slack.getSlackReceiverId())
+			.message(slack.getSlackMessage())
+			.sentAt(slack.getCreatedAt())
+			.build());
+
+		return new CommonResponse<>(SuccessCode.SLACK_MESSAGE_LIST_FOUND, responseDtoPage);
+	}
+
+	private void validateMasterRole() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			throw new CustomApiException(SlackException.UNAUTHORIZED_ACCESS);
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (!(principal instanceof RequestUserDetails userDetails)) {
+			throw new CustomApiException(SlackException.UNAUTHORIZED_ACCESS);
+		}
+
+		boolean isMaster = userDetails.getAuthorities().stream()
+			.anyMatch(auth -> auth.getAuthority().equals("ROLE_MASTER"));
+
+		if (!isMaster) {
+			throw new CustomApiException(SlackException.UNAUTHORIZED_ACCESS);
+		}
 	}
 }

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/domain/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/domain/repository/SlackRepository.java
@@ -2,9 +2,15 @@ package com.fn.eureka.client.slackservice.domain.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.fn.eureka.client.slackservice.domain.entity.Slack;
 
 public interface SlackRepository extends JpaRepository<Slack, UUID> {
+	@Query("SELECT s FROM Slack s WHERE " +
+		"(:keyword IS NULL OR LOWER(s.slackMessage) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+	Page<Slack> findByKeyword(String keyword, Pageable pageable);
 }

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/presentation/controller/SlackController.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/presentation/controller/SlackController.java
@@ -1,12 +1,19 @@
 package com.fn.eureka.client.slackservice.presentation.controller;
 
+import com.fn.common.global.dto.CommonResponse;
+import com.fn.common.global.success.SuccessCode;
 import com.fn.eureka.client.slackservice.application.dto.request.SlackMessageRequestDto;
+import com.fn.eureka.client.slackservice.application.dto.response.SlackGetResponseDto;
 import com.fn.eureka.client.slackservice.application.dto.response.SlackMessageResponseDto;
 import com.fn.eureka.client.slackservice.application.service.SlackService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/slack")
@@ -16,10 +23,26 @@ public class SlackController {
 	private final SlackService slackService;
 
 	@PostMapping
-	public ResponseEntity<SlackMessageResponseDto> sendSlackMessage(@RequestBody SlackMessageRequestDto requestDto) {
-		SlackMessageResponseDto responseDto = slackService.sendSlackMessage(requestDto);
+	public ResponseEntity<CommonResponse<SlackMessageResponseDto>> sendSlackMessage(
+		@RequestBody SlackMessageRequestDto requestDto) {
+		CommonResponse<SlackMessageResponseDto> response = slackService.sendSlackMessage(requestDto);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+		return ResponseEntity.status(SuccessCode.SLACK_MESSAGE_SENT.getStatusCode()).body(response);
+	}
+
+	@GetMapping("/{slackId}")
+	public ResponseEntity<CommonResponse<SlackGetResponseDto>> getSlackMessage(@PathVariable UUID slackId) {
+		CommonResponse<SlackGetResponseDto> response = slackService.getSlackMessage(slackId);
+
+		return ResponseEntity.status(SuccessCode.SLACK_MESSAGE_FOUND.getStatusCode()).body(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<CommonResponse<Page<SlackGetResponseDto>>> getSlackMessages(
+		@RequestParam(required = false) String keyword,
+		Pageable pageable) {
+
+		CommonResponse<Page<SlackGetResponseDto>> response = slackService.getSlackMessages(keyword, pageable);
+		return ResponseEntity.status(SuccessCode.SLACK_MESSAGE_LIST_FOUND.getStatusCode()).body(response);
 	}
 }
-


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**
    - Slack 메시지 단건 조회 구현
    - Slack 메시지 전체 조회 구현
    - Slack 메시지 검색 기능 구현
    - CommonResponse<T>로 일관된 응답 반환하도록 수정

## 코멘트
- MVP 개발 후 QueryDSL 도입 고려