### PR TITLE
Feat/#70 delete slack

### DIFF
--- a/common/src/main/java/com/fn/common/global/success/SuccessCode.java
+++ b/common/src/main/java/com/fn/common/global/success/SuccessCode.java
@@ -40,7 +40,8 @@ public enum SuccessCode {
 	SLACK_MESSAGE_SENT(HttpStatus.CREATED, "Slack 메시지가 성공적으로 전송되었습니다.", "S_SLACK_MESSAGE_SENT"),
 	SLACK_MESSAGE_FOUND(HttpStatus.OK, "Slack 메시지가 성공적으로 조회되었습니다.", "S_SLACK_MESSAGE_FOUND"),
 	SLACK_MESSAGE_LIST_FOUND(HttpStatus.OK, "Slack 메시지 목록이 성공적으로 조회되었습니다.", "S_SLACK_MESSAGE_LIST_FOUND"),
-	SLACK_MESSAGE_UPDATED(HttpStatus.OK, "Slack 메시지가 성공적으로 수정되었습니다.", "S_SLACK_MESSAGE_UPDATED")
+	SLACK_MESSAGE_UPDATED(HttpStatus.OK, "Slack 메시지가 성공적으로 수정되었습니다.", "S_SLACK_MESSAGE_UPDATED"),
+	SLACK_MESSAGE_DELETED(HttpStatus.NO_CONTENT, "Slack 메시지가 성공적으로 삭제되었습니다.", "S_SLACK_MESSAGE_DELETED")
 	;
 
 	private final HttpStatus statusCode;

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/dto/response/SlackGetResponseDto.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/dto/response/SlackGetResponseDto.java
@@ -12,4 +12,7 @@ public class SlackGetResponseDto {
 	private String receiverId;
 	private String message;
 	private LocalDateTime sentAt;
+	private boolean isDeleted;
+	private LocalDateTime deletedAt;
 }
+

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/service/SlackService.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/service/SlackService.java
@@ -70,6 +70,8 @@ public class SlackService {
 			.receiverId(slackMessage.getSlackReceiverId())
 			.message(slackMessage.getSlackMessage())
 			.sentAt(slackMessage.getCreatedAt())
+			.isDeleted(slackMessage.isDeleted()) // 삭제 여부 포함
+			.deletedAt(slackMessage.getDeletedAt()) // 삭제된 경우 삭제 시점 포함
 			.build();
 
 		return new CommonResponse<>(SuccessCode.SLACK_MESSAGE_FOUND, responseDto);
@@ -88,10 +90,13 @@ public class SlackService {
 			.receiverId(slack.getSlackReceiverId())
 			.message(slack.getSlackMessage())
 			.sentAt(slack.getCreatedAt())
+			.isDeleted(slack.isDeleted()) // 삭제 여부 포함
+			.deletedAt(slack.getDeletedAt()) // 삭제된 경우 삭제 시점 포함
 			.build());
 
 		return new CommonResponse<>(SuccessCode.SLACK_MESSAGE_LIST_FOUND, responseDtoPage);
 	}
+
 
 	@Transactional
 	public CommonResponse<SlackUpdateResponseDto> updateSlackMessage(UUID slackId, SlackUpdateRequestDto requestDto) {

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/service/SlackService.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/application/service/SlackService.java
@@ -133,4 +133,17 @@ public class SlackService {
 			throw new CustomApiException(SlackException.UNAUTHORIZED_ACCESS);
 		}
 	}
+
+	@Transactional
+	public CommonResponse<Void> deleteSlackMessage(UUID slackId) {
+		validateMasterRole();
+
+		Slack slackMessage = slackRepository.findById(slackId)
+			.orElseThrow(() -> new CustomApiException(SlackException.SLACK_MESSAGE_NOT_FOUND));
+
+		slackMessage.markAsDeleted();
+
+		return new CommonResponse<>(SuccessCode.SLACK_MESSAGE_DELETED, null);
+	}
+
 }

--- a/slack-service/src/main/java/com/fn/eureka/client/slackservice/presentation/controller/SlackController.java
+++ b/slack-service/src/main/java/com/fn/eureka/client/slackservice/presentation/controller/SlackController.java
@@ -57,4 +57,11 @@ public class SlackController {
 
 		return ResponseEntity.status(SuccessCode.SLACK_MESSAGE_UPDATED.getStatusCode()).body(response);
 	}
+
+	@DeleteMapping("/{slackId}")
+	public ResponseEntity<CommonResponse<Void>> deleteSlackMessage(@PathVariable UUID slackId) {
+		CommonResponse<Void> response = slackService.deleteSlackMessage(slackId);
+
+		return ResponseEntity.status(SuccessCode.SLACK_MESSAGE_DELETED.getStatusCode()).body(response);
+	}
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**
    - Slack 메시지 삭제 기능 추가
    - 조회 시 삭제된 메시지 명시

## 코멘트
- 마스터 권한만 조회 가능하여 삭제된 데이터도 조회 가능하게 하였으며, isDeleted 필드로 삭제 여부를 표시함
