### PR TITLE
Feat/#81 주문 조회

### DIFF
--- a/common/src/main/java/com/fn/common/global/success/SuccessCode.java
+++ b/common/src/main/java/com/fn/common/global/success/SuccessCode.java
@@ -8,6 +8,13 @@ import lombok.Getter;
 public enum SuccessCode {
 
 	// 여기서 공통 성공 응답 생성
+	// Order 관련 성공응답
+	ORDER_CREATE(HttpStatus.CREATED, "주문이 성공적으로 생성되었습니다.", "S_ORDER_CREATE"),
+	ORDER_SEARCH_ONE(HttpStatus.OK, "단건 주문이 성공적으로 조회되었습니다.", "S_ORDER_SEARCH_ONE"),
+	ORDER_SEARCH_ALL(HttpStatus.OK, "모든 주문이 성공적으로 조회되었습니다.","S_ORDER_SEARCH_ALL" ),
+	ORDER_UPDATE(HttpStatus.OK, "주문이 성공적으로 수정되었습니다.", "S_ORDER_UPDATE" ),
+	ORDER_DELETE(HttpStatus.NO_CONTENT, "해당 주문이 삭제되었습니다.", "S_ORDER_DELETE" ),
+
     // HubToHub 관련 성공응답
 	HUBTOHUB_CREATE(HttpStatus.CREATED, "루트가 성공적으로 생성되었습니다.", "S_HUBTOHUB_CREATE"),
 	HUBTOHUB_SEARCH_ALL(HttpStatus.OK, "모든 루트가 성공적으로 조회되었습니다.","S_HUBTOHUB_SEARCH_ALL" ),

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/CompanyServiceApplication.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/CompanyServiceApplication.java
@@ -8,8 +8,9 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableFeignClients
 @EnableDiscoveryClient
-// @SpringBootApplication(scanBasePackages = {"com.fn.common"})
-@SpringBootApplication(scanBasePackages = {"com.fn.eureka.client.companyservice.config"})
+@SpringBootApplication(
+	scanBasePackages = {"com.fn.eureka.client.companyservice", "com.fn.common"},
+	exclude = SecurityAutoConfiguration.class)
 public class CompanyServiceApplication {
 
 	public static void main(String[] args) {

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/application/CompanyService.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/application/CompanyService.java
@@ -1,5 +1,6 @@
 package com.fn.eureka.client.companyservice.application;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -20,4 +21,8 @@ public interface CompanyService {
 	CompanyResponseDto modifyCompany(UUID companyId, CompanyRequestDto requestDto);
 
 	void removeCompany(UUID companyId);
+
+	List<UUID> findAllCompaniesByHubId(UUID hubId);
+
+	UUID findCompanyIdByCompanyManagerId(UUID companyManagerId);
 }

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/application/CompanyServiceImpl.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/application/CompanyServiceImpl.java
@@ -1,6 +1,8 @@
 package com.fn.eureka.client.companyservice.application;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
@@ -82,6 +84,19 @@ public class CompanyServiceImpl implements CompanyService {
 		Company company = companyRepository.findById(companyId)
 			.orElseThrow(() -> new NotFoundException("해당 업체를 찾을 수 없습니다"));
 		company.markAsDeleted();
+	}
+
+	// for other services...
+
+	// 허브별 업체ID 목록 조회
+	@Override
+	public List<UUID> findAllCompaniesByHubId(UUID hubId) {
+		return companyQueryRepository.findCompanyIdByCompanyHubId(hubId);
+	}
+
+	@Override
+	public UUID findCompanyIdByCompanyManagerId(UUID companyManagerId) {
+		return companyQueryRepository.findCompanyIdByCompanyManagerId(companyManagerId);
 	}
 
 }

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/config/AuthenticationFilter.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/config/AuthenticationFilter.java
@@ -33,7 +33,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 		log.info("현재 요청 URI: {}", requestUri);
 
 		// 인증 예외 경로
-		if (requestUri.startsWith("/swagger-ui/") ||
+		if (requestUri.startsWith("/api/") ||
+			requestUri.startsWith("/swagger-ui/") ||
 			requestUri.startsWith("/v3/api-docs"))
 		{
 			log.info("인증 예외 경로 - 필터 통과: {}", requestUri);

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/domain/repository/CompanyQueryRepository.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/domain/repository/CompanyQueryRepository.java
@@ -34,6 +34,7 @@ public class CompanyQueryRepository {
 		this.queryFactory = queryFactory;
 	}
 
+	// 업체 리스트 조회
 	public Page<CompanyResponseDto> findCompaniesByType(UUID hubId, String type, String keyword, Pageable pageable,
 		Sort.Direction sortDirection, PageUtils.CommonSortBy sortBy,
 		String userRole) {
@@ -73,4 +74,25 @@ public class CompanyQueryRepository {
 
 		return new PageImpl<>(dtoList, pageable, total);
 	}
+
+	// 허브별 업체ID 목록 조회
+	public List<UUID> findCompanyIdByCompanyHubId(UUID hubId) {
+		QCompany company = QCompany.company;
+		return queryFactory
+			.select(company.companyId)
+			.from(company)
+			.where(company.companyHubId.eq(hubId))
+			.fetch();
+	}
+
+	// 업체담당자ID로 업체ID 조회
+	public UUID findCompanyIdByCompanyManagerId(UUID companyManagerId) {
+		QCompany company = QCompany.company;
+		return queryFactory
+			.select(company.companyId)
+			.from(company)
+			.where(company.companyManagerId.eq(companyManagerId))
+			.fetchOne();
+	}
+
 }

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/domain/repository/CompanyRepository.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/domain/repository/CompanyRepository.java
@@ -1,8 +1,10 @@
 package com.fn.eureka.client.companyservice.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.fn.eureka.client.companyservice.domain.entity.Company;

--- a/company-service/src/main/java/com/fn/eureka/client/companyservice/presentation/CompanyController.java
+++ b/company-service/src/main/java/com/fn/eureka/client/companyservice/presentation/CompanyController.java
@@ -1,5 +1,6 @@
 package com.fn.eureka.client.companyservice.presentation;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -22,7 +23,9 @@ import com.fn.eureka.client.companyservice.presentation.dto.CompanyRequestDto;
 import com.fn.eureka.client.companyservice.presentation.dto.CompanyResponseDto;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/companies")
@@ -76,5 +79,19 @@ public class CompanyController {
 	public ResponseEntity<Void> deleteCompany(@PathVariable("companyId") UUID companyId) {
 		companyService.removeCompany(companyId);
 		return ResponseEntity.noContent().build();
+	}
+
+	// for other services...
+
+	// 허브에 소속된 업체ID 목록 조회
+	@GetMapping("/hub/{hubId}")
+	public List<UUID> readCompaniesByHubId(@PathVariable("hubId") UUID hubId) {
+		return companyService.findAllCompaniesByHubId(hubId);
+	}
+
+	// 업체담당자ID로 업체 조회
+	@GetMapping("/company-manager/{companyManagerId}")
+	UUID readCompanyIdByCompanyManagerId(@PathVariable("companyManagerId")UUID companyManagerId) {
+		return companyService.findCompanyIdByCompanyManagerId(companyManagerId);
 	}
 }

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -42,6 +42,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.postgresql:postgresql'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation 'com.querydsl:querydsl-core'
+
+    // QueryDSL Annotation Processor (QClass 자동 생성)
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/OrderService.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/OrderService.java
@@ -1,8 +1,12 @@
 package com.fn.eureka.client.orderservice.application;
 
+import java.util.UUID;
+
 import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
 
 public interface OrderService {
 	OrderResponseDto addOrder(OrderRequestDto requestDto);
+
+	OrderResponseDto findOrder(UUID orderId);
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/OrderService.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/OrderService.java
@@ -2,6 +2,10 @@ package com.fn.eureka.client.orderservice.application;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+
+import com.fn.common.global.util.PageUtils;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
 
@@ -9,4 +13,6 @@ public interface OrderService {
 	OrderResponseDto addOrder(OrderRequestDto requestDto);
 
 	OrderResponseDto findOrder(UUID orderId);
+
+	Page<OrderResponseDto> findAllOrdersByRole(String keyword, int page, int size, Sort.Direction sortDirection, PageUtils.CommonSortBy sortBy, String userRole, UUID userId);
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/OrderServiceImpl.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fn.common.global.exception.ConflictException;
+import com.fn.common.global.exception.CustomApiException;
 import com.fn.eureka.client.orderservice.domain.Order;
 import com.fn.eureka.client.orderservice.domain.OrderRepository;
+import com.fn.eureka.client.orderservice.exception.OrderException;
 import com.fn.eureka.client.orderservice.infrastructure.CompanyServiceClient;
 import com.fn.eureka.client.orderservice.infrastructure.DeliveryServiceClient;
 import com.fn.eureka.client.orderservice.infrastructure.HubServiceClient;
@@ -41,15 +43,15 @@ public class OrderServiceImpl implements OrderService {
 	@Override
 	@Transactional
 	public OrderResponseDto addOrder(OrderRequestDto orderRequestDto) {
-		UUID supplyCompanyId = orderRequestDto.getOrderSupplyCompanyId();	// 공급업체 ID
-		CompanyInfoDto supplyCompanyInfo = companyServiceClient.getCompany(supplyCompanyId);
+		// UUID supplyCompanyId = orderRequestDto.getOrderSupplyCompanyId();	// 공급업체 ID
+		// CompanyInfoDto supplyCompanyInfo = companyServiceClient.getCompany(supplyCompanyId);
 		// // 공급업체의 허브ID 검색 후 허브 재고 조회
 		// UUID supplyCompanyHubId = supplyCompanyInfo.getCompanyHubId();	// 공급업체 담당 허브 ID
 		// UUID orderProductId = orderRequestDto.getOrderProductId();	// 주문상품 ID
 		// HubStockResponseDto hubStockInfo = hubServiceClient.searchHubStock(supplyCompanyHubId, orderProductId);
 		// // 재고 부족 예외 처리
 		// if (hubStockInfo.getHsQuantity() < orderRequestDto.getOrderProductQuantity()) {
-		// 	throw new ConflictException("허브에 해당 상품의 재고가 부족합니다.");
+		// 	throw new CustomApiException(OrderException.HUB_INSUFFICIENT_STOCK);
 		// }
 
 		// 주문 생성
@@ -73,6 +75,14 @@ public class OrderServiceImpl implements OrderService {
 		//
 		// // 생성된 배송ID 받아 저장
 		// order.saveOrderDeliveryId(deliveryInfo.getDeliveryId());
+		return new OrderResponseDto(order);
+	}
+
+	// 주문 조회
+	@Override
+	public OrderResponseDto findOrder(UUID orderId) {
+		Order order = orderRepository.findByOrderIdAndIsDeletedFalse(orderId)
+			.orElseThrow(() -> new CustomApiException(OrderException.ORDER_NOT_FOUND));
 		return new OrderResponseDto(order);
 	}
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/CompanyInfoDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/CompanyInfoDto.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.application.dto;
 
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/DeliveryRequestDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/DeliveryRequestDto.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.application.dto;
 
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/DeliveryResponseDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/DeliveryResponseDto.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.application.dto;
 
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/HubStockResponseDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/HubStockResponseDto.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.application.dto;
 
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/OrderResponseDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/OrderResponseDto.java
@@ -1,9 +1,9 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.application.dto;
 
 import java.sql.Timestamp;
 import java.util.UUID;
 
-import com.fn.eureka.client.orderservice.domain.Order;
+import com.fn.eureka.client.orderservice.domain.model.Order;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/UserResponseDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/application/dto/UserResponseDto.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.application.dto;
 
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/OrderRepository.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/OrderRepository.java
@@ -1,5 +1,6 @@
 package com.fn.eureka.client.orderservice.domain;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+	Optional<Order> findByOrderIdAndIsDeletedFalse(UUID orderId);
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/model/Order.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/model/Order.java
@@ -1,10 +1,10 @@
-package com.fn.eureka.client.orderservice.domain;
+package com.fn.eureka.client.orderservice.domain.model;
 
 import java.sql.Timestamp;
 import java.util.UUID;
 
 import com.fn.common.global.BaseEntity;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
+import com.fn.eureka.client.orderservice.presentation.request.OrderRequestDto;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderQueryRepository.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderQueryRepository.java
@@ -1,89 +1,17 @@
 package com.fn.eureka.client.orderservice.domain.repository;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Repository;
 
 import com.fn.common.global.util.PageUtils;
-import com.fn.eureka.client.orderservice.domain.Order;
-import com.fn.eureka.client.orderservice.domain.QOrder;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.impl.JPAQuery;
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.fn.eureka.client.orderservice.application.dto.OrderResponseDto;
 
-import jakarta.persistence.EntityManager;
+public interface OrderQueryRepository {
 
-@Repository
-public class OrderQueryRepository {
-
-	private final JPAQueryFactory queryFactory;
-
-	public OrderQueryRepository(EntityManager entityManager) {
-		this.queryFactory = new JPAQueryFactory(entityManager);
-	}
-
-	// List<UUID> companies, List<UUID> deliveries,
-	public Page<OrderResponseDto> findAllOrdersByRole(
+	Page<OrderResponseDto> findAllOrdersByRole(
 		String keyword, Pageable pageable, String userRole, UUID userId, UUID companyId,
-		Sort.Direction sortDirection, PageUtils.CommonSortBy sortBy) {
-		QOrder order = QOrder.order;
-		BooleanBuilder builder = new BooleanBuilder();
-
-		// 기본 조건: 삭제되지 않은 주문
-		builder.and(order.isDeleted.eq(false));
-
-		// // 허브별 조회
-		// if ("HUB_MANAGER".equals(userRole) && companies != null && !companies.isEmpty()) {
-		// 	builder.and(order.orderSupplyCompanyId.in(companies)
-		// 		.or(order.orderReceiveCompanyId.in(companies)));
-		// }
-		//
-		// // 배송담당자별 조회
-		// if ("DELIVERY_MANAGER".equals(userRole) && deliveries != null && !deliveries.isEmpty()) {
-		// 	builder.and(order.orderDeliveryId.in(deliveries));
-		// }
-
-		// 업체별 조회
-		if ("COMPANY_MANAGER".equals(userRole) && companyId != null) {
-			builder.and(order.orderSupplyCompanyId.in(companyId)
-				.or(order.orderReceiveCompanyId.in(companyId)));
-		}
-
-		// 검색어 (주문번호) - 근데 주문은 뭐로 검색해야 맞을지 모르겠긴 함...
-		if (keyword != null && !keyword.isEmpty()) {
-			builder.and(Expressions.stringTemplate("CAST({0} AS string)", order.orderId)
-				.containsIgnoreCase(keyword));
-		}
-
-		// 정렬 적용
-		OrderSpecifier<?> orderSpecifier = PageUtils.getCommonOrderSpecifier(order, sortDirection, sortBy);
-
-		// QueryDSL 실행
-		JPAQuery<Order> query = queryFactory
-			.selectFrom(order)
-			.where(builder)
-			.orderBy(orderSpecifier)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize());
-
-		List<Order> orders = query.fetch();
-		long total = query.fetchCount();
-
-		// DTO 변환
-		List<OrderResponseDto> dtoList = orders.stream()
-			.map(OrderResponseDto::new)
-			.collect(Collectors.toList());
-
-		return new PageImpl<>(dtoList, pageable, total);
-	}
-
+		Sort.Direction sortDirection, PageUtils.CommonSortBy sortBy);
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderQueryRepository.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderQueryRepository.java
@@ -1,0 +1,89 @@
+package com.fn.eureka.client.orderservice.domain.repository;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import com.fn.common.global.util.PageUtils;
+import com.fn.eureka.client.orderservice.domain.Order;
+import com.fn.eureka.client.orderservice.domain.QOrder;
+import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Repository
+public class OrderQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public OrderQueryRepository(EntityManager entityManager) {
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	// List<UUID> companies, List<UUID> deliveries,
+	public Page<OrderResponseDto> findAllOrdersByRole(
+		String keyword, Pageable pageable, String userRole, UUID userId, UUID companyId,
+		Sort.Direction sortDirection, PageUtils.CommonSortBy sortBy) {
+		QOrder order = QOrder.order;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 기본 조건: 삭제되지 않은 주문
+		builder.and(order.isDeleted.eq(false));
+
+		// // 허브별 조회
+		// if ("HUB_MANAGER".equals(userRole) && companies != null && !companies.isEmpty()) {
+		// 	builder.and(order.orderSupplyCompanyId.in(companies)
+		// 		.or(order.orderReceiveCompanyId.in(companies)));
+		// }
+		//
+		// // 배송담당자별 조회
+		// if ("DELIVERY_MANAGER".equals(userRole) && deliveries != null && !deliveries.isEmpty()) {
+		// 	builder.and(order.orderDeliveryId.in(deliveries));
+		// }
+
+		// 업체별 조회
+		if ("COMPANY_MANAGER".equals(userRole) && companyId != null) {
+			builder.and(order.orderSupplyCompanyId.in(companyId)
+				.or(order.orderReceiveCompanyId.in(companyId)));
+		}
+
+		// 검색어 (주문번호) - 근데 주문은 뭐로 검색해야 맞을지 모르겠긴 함...
+		if (keyword != null && !keyword.isEmpty()) {
+			builder.and(Expressions.stringTemplate("CAST({0} AS string)", order.orderId)
+				.containsIgnoreCase(keyword));
+		}
+
+		// 정렬 적용
+		OrderSpecifier<?> orderSpecifier = PageUtils.getCommonOrderSpecifier(order, sortDirection, sortBy);
+
+		// QueryDSL 실행
+		JPAQuery<Order> query = queryFactory
+			.selectFrom(order)
+			.where(builder)
+			.orderBy(orderSpecifier)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize());
+
+		List<Order> orders = query.fetch();
+		long total = query.fetchCount();
+
+		// DTO 변환
+		List<OrderResponseDto> dtoList = orders.stream()
+			.map(OrderResponseDto::new)
+			.collect(Collectors.toList());
+
+		return new PageImpl<>(dtoList, pageable, total);
+	}
+
+}

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderRepository.java
@@ -1,10 +1,12 @@
-package com.fn.eureka.client.orderservice.domain;
+package com.fn.eureka.client.orderservice.domain.repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import com.fn.eureka.client.orderservice.domain.Order;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, UUID> {

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/repository/OrderRepository.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.fn.eureka.client.orderservice.domain.Order;
+import com.fn.eureka.client.orderservice.domain.model.Order;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, UUID> {

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/service/OrderService.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/domain/service/OrderService.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.application;
+package com.fn.eureka.client.orderservice.domain.service;
 
 import java.util.UUID;
 
@@ -6,8 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 
 import com.fn.common.global.util.PageUtils;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
+import com.fn.eureka.client.orderservice.presentation.request.OrderRequestDto;
+import com.fn.eureka.client.orderservice.application.dto.OrderResponseDto;
 
 public interface OrderService {
 	OrderResponseDto addOrder(OrderRequestDto requestDto);

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/exception/OrderException.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/exception/OrderException.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 public enum OrderException implements ExceptionType {
-	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다.", "E_ORDER_NOT_FOUND"),
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 조회할 수 없습니다.", "E_ORDER_NOT_FOUND"),
 	HUB_INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "허브에 재고가 부족합니다.", "E_HUB_INSUFFICIENT_STOCK");
 
 	private final HttpStatus httpStatus;

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/exception/OrderException.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/exception/OrderException.java
@@ -1,0 +1,24 @@
+package com.fn.eureka.client.orderservice.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.fn.common.global.exception.type.ExceptionType;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderException implements ExceptionType {
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다.", "E_ORDER_NOT_FOUND"),
+	HUB_INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "허브에 재고가 부족합니다.", "E_HUB_INSUFFICIENT_STOCK");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+	private final String errorCode;
+
+	OrderException(HttpStatus httpStatus, String message, String errorCode) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+		this.errorCode = errorCode;
+	}
+
+}

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/CompanyServiceClient.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/CompanyServiceClient.java
@@ -1,15 +1,32 @@
 package com.fn.eureka.client.orderservice.infrastructure;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import com.fn.common.global.util.PageUtils;
 import com.fn.eureka.client.orderservice.presentation.dto.CompanyInfoDto;
 
 @FeignClient(name = "company-service", path = "/api/companies")
 public interface CompanyServiceClient {
+
+	// 업체 조회
 	@GetMapping("/{companyId}")
 	CompanyInfoDto getCompany(@PathVariable("companyId") UUID companyId);
+
+	// 허브별 업체ID 목록 조회
+	@GetMapping("/hub/{hubId}")
+	List<UUID> readCompaniesByHubId(@PathVariable("hubId") UUID hubId);
+
+	// 업체담당자ID로 업체ID 조회
+	@GetMapping("/company-manager/{companyManagerId}")
+	UUID readCompanyIdByCompanyManagerId(@PathVariable("companyManagerId")UUID companyManagerId);
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/CompanyServiceClient.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/CompanyServiceClient.java
@@ -1,19 +1,13 @@
-package com.fn.eureka.client.orderservice.infrastructure;
+package com.fn.eureka.client.orderservice.infrastructure.client;
 
 import java.util.List;
 import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 
-import com.fn.common.global.util.PageUtils;
-import com.fn.eureka.client.orderservice.presentation.dto.CompanyInfoDto;
+import com.fn.eureka.client.orderservice.application.dto.CompanyInfoDto;
 
 @FeignClient(name = "company-service", path = "/api/companies")
 public interface CompanyServiceClient {

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/DeliveryServiceClient.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/DeliveryServiceClient.java
@@ -1,11 +1,11 @@
-package com.fn.eureka.client.orderservice.infrastructure;
+package com.fn.eureka.client.orderservice.infrastructure.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import com.fn.eureka.client.orderservice.presentation.dto.DeliveryRequestDto;
-import com.fn.eureka.client.orderservice.presentation.dto.DeliveryResponseDto;
+import com.fn.eureka.client.orderservice.application.dto.DeliveryRequestDto;
+import com.fn.eureka.client.orderservice.application.dto.DeliveryResponseDto;
 
 @FeignClient(name = "delivery-service", path = "/api/deliveries")
 public interface DeliveryServiceClient {

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/HubServiceClient.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/HubServiceClient.java
@@ -1,15 +1,13 @@
-package com.fn.eureka.client.orderservice.infrastructure;
+package com.fn.eureka.client.orderservice.infrastructure.client;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.fn.eureka.client.orderservice.presentation.dto.HubStockResponseDto;
+import com.fn.eureka.client.orderservice.application.dto.HubStockResponseDto;
 
 @FeignClient(name = "hub-service", path = "/api/hubs")
 public interface HubServiceClient {

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/UserServiceClient.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/client/UserServiceClient.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.infrastructure;
+package com.fn.eureka.client.orderservice.infrastructure.client;
 
 import java.util.UUID;
 
@@ -6,9 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import com.fn.eureka.client.orderservice.presentation.dto.UserResponseDto;
-
-import feign.FeignException;
+import com.fn.eureka.client.orderservice.application.dto.UserResponseDto;
 
 @FeignClient(name = "user-service", path = "/api/users")
 public interface UserServiceClient {

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/config/AuthenticationFilter.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/config/AuthenticationFilter.java
@@ -1,15 +1,9 @@
-package com.fn.eureka.client.orderservice.config;
+package com.fn.eureka.client.orderservice.infrastructure.config;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/config/RequestUserDetails.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/config/RequestUserDetails.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.config;
+package com.fn.eureka.client.orderservice.infrastructure.config;
 
 import java.util.Collection;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/config/SecurityConfig.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.config;
+package com.fn.eureka.client.orderservice.infrastructure.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/exception/OrderException.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/exception/OrderException.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.exception;
+package com.fn.eureka.client.orderservice.infrastructure.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/repository/OrderQueryRepositoryImpl.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/repository/OrderQueryRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.fn.eureka.client.orderservice.infrastructure.repository;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import com.fn.common.global.util.PageUtils;
+import com.fn.eureka.client.orderservice.domain.model.Order;
+import com.fn.eureka.client.orderservice.domain.QOrder;
+import com.fn.eureka.client.orderservice.application.dto.OrderResponseDto;
+import com.fn.eureka.client.orderservice.domain.repository.OrderQueryRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Repository
+public class OrderQueryRepositoryImpl implements OrderQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public OrderQueryRepositoryImpl(EntityManager entityManager) {
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	// List<UUID> companies, List<UUID> deliveries,
+	public Page<OrderResponseDto> findAllOrdersByRole(
+		String keyword, Pageable pageable, String userRole, UUID userId, UUID companyId,
+		Sort.Direction sortDirection, PageUtils.CommonSortBy sortBy) {
+		QOrder order = QOrder.order;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 기본 조건: 삭제되지 않은 주문
+		builder.and(order.isDeleted.eq(false));
+
+		// // 허브별 조회
+		// if ("HUB_MANAGER".equals(userRole) && companies != null && !companies.isEmpty()) {
+		// 	builder.and(order.orderSupplyCompanyId.in(companies)
+		// 		.or(order.orderReceiveCompanyId.in(companies)));
+		// }
+		//
+		// // 배송담당자별 조회
+		// if ("DELIVERY_MANAGER".equals(userRole) && deliveries != null && !deliveries.isEmpty()) {
+		// 	builder.and(order.orderDeliveryId.in(deliveries));
+		// }
+
+		// 업체별 조회
+		if ("COMPANY_MANAGER".equals(userRole) && companyId != null) {
+			builder.and(order.orderSupplyCompanyId.in(companyId)
+				.or(order.orderReceiveCompanyId.in(companyId)));
+		}
+
+		// 검색어 (주문번호) - 근데 주문은 뭐로 검색해야 맞을지 모르겠긴 함...
+		if (keyword != null && !keyword.isEmpty()) {
+			builder.and(Expressions.stringTemplate("CAST({0} AS string)", order.orderId)
+				.containsIgnoreCase(keyword));
+		}
+
+		// 정렬 적용
+		OrderSpecifier<?> orderSpecifier = PageUtils.getCommonOrderSpecifier(order, sortDirection, sortBy);
+
+		// QueryDSL 실행
+		JPAQuery<Order> query = queryFactory
+			.selectFrom(order)
+			.where(builder)
+			.orderBy(orderSpecifier)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize());
+
+		List<Order> orders = query.fetch();
+		long total = query.fetchCount();
+
+		// DTO 변환
+		List<OrderResponseDto> dtoList = orders.stream()
+			.map(OrderResponseDto::new)
+			.collect(Collectors.toList());
+
+		return new PageImpl<>(dtoList, pageable, total);
+	}
+
+}

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/service/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/infrastructure/service/OrderServiceImpl.java
@@ -1,6 +1,5 @@
-package com.fn.eureka.client.orderservice.application;
+package com.fn.eureka.client.orderservice.infrastructure.service;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -10,16 +9,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fn.common.global.exception.CustomApiException;
 import com.fn.common.global.util.PageUtils;
-import com.fn.eureka.client.orderservice.domain.Order;
-import com.fn.eureka.client.orderservice.domain.repository.OrderQueryRepository;
+import com.fn.eureka.client.orderservice.domain.model.Order;
+import com.fn.eureka.client.orderservice.domain.service.OrderService;
+import com.fn.eureka.client.orderservice.infrastructure.repository.OrderQueryRepositoryImpl;
 import com.fn.eureka.client.orderservice.domain.repository.OrderRepository;
-import com.fn.eureka.client.orderservice.exception.OrderException;
-import com.fn.eureka.client.orderservice.infrastructure.CompanyServiceClient;
-import com.fn.eureka.client.orderservice.infrastructure.DeliveryServiceClient;
-import com.fn.eureka.client.orderservice.infrastructure.HubServiceClient;
-import com.fn.eureka.client.orderservice.infrastructure.UserServiceClient;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
+import com.fn.eureka.client.orderservice.infrastructure.exception.OrderException;
+import com.fn.eureka.client.orderservice.infrastructure.client.CompanyServiceClient;
+import com.fn.eureka.client.orderservice.infrastructure.client.DeliveryServiceClient;
+import com.fn.eureka.client.orderservice.infrastructure.client.HubServiceClient;
+import com.fn.eureka.client.orderservice.infrastructure.client.UserServiceClient;
+import com.fn.eureka.client.orderservice.presentation.request.OrderRequestDto;
+import com.fn.eureka.client.orderservice.application.dto.OrderResponseDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderServiceImpl implements OrderService {
 
 	private final OrderRepository orderRepository;
-	private final OrderQueryRepository orderQueryRepository;
+	private final OrderQueryRepositoryImpl orderQueryRepository;
 
 	private final UserServiceClient userServiceClient;
 	private final CompanyServiceClient companyServiceClient;

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/OrderController.java
@@ -1,15 +1,20 @@
 package com.fn.eureka.client.orderservice.presentation;
 
+import java.net.URI;
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.fn.common.global.dto.CommonResponse;
+import com.fn.common.global.success.SuccessCode;
 import com.fn.eureka.client.orderservice.application.OrderService;
-import com.fn.eureka.client.orderservice.infrastructure.CompanyServiceClient;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
 
@@ -24,10 +29,18 @@ public class OrderController {
 
 	private final OrderService orderService;
 
+	// 주문 생성
 	@PostMapping
-	public ResponseEntity<OrderResponseDto> createOrder(@RequestBody OrderRequestDto requestDto) {
-		log.info("Create order request: {}", requestDto);
-		OrderResponseDto response = orderService.addOrder(requestDto);
-		return ResponseEntity.ok(response);
+	public ResponseEntity<CommonResponse<OrderResponseDto>> createOrder(@RequestBody OrderRequestDto orderRequestDto) {
+		OrderResponseDto orderResponseDto = orderService.addOrder(orderRequestDto);
+		URI location = ServletUriComponentsBuilder.fromCurrentContextPath().path("/api/orders").build().toUri();
+		return ResponseEntity.created(location).body(new CommonResponse<>(SuccessCode.ORDER_CREATE, orderResponseDto));
+	}
+
+	// 주문 조회
+	@GetMapping("/{orderId}")
+	public ResponseEntity<CommonResponse<OrderResponseDto>> readOrder(@PathVariable("orderId")UUID orderId) {
+		OrderResponseDto orderResponseDto = orderService.findOrder(orderId);
+		return ResponseEntity.ok().body(new CommonResponse<>(SuccessCode.ORDER_SEARCH_ONE, orderResponseDto));
 	}
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/OrderController.java
@@ -19,9 +19,9 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import com.fn.common.global.dto.CommonResponse;
 import com.fn.common.global.success.SuccessCode;
 import com.fn.common.global.util.PageUtils;
-import com.fn.eureka.client.orderservice.application.OrderService;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
-import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
+import com.fn.eureka.client.orderservice.domain.service.OrderService;
+import com.fn.eureka.client.orderservice.presentation.request.OrderRequestDto;
+import com.fn.eureka.client.orderservice.application.dto.OrderResponseDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/OrderController.java
@@ -3,17 +3,22 @@ package com.fn.eureka.client.orderservice.presentation;
 import java.net.URI;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.fn.common.global.dto.CommonResponse;
 import com.fn.common.global.success.SuccessCode;
+import com.fn.common.global.util.PageUtils;
 import com.fn.eureka.client.orderservice.application.OrderService;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderRequestDto;
 import com.fn.eureka.client.orderservice.presentation.dto.OrderResponseDto;
@@ -42,5 +47,20 @@ public class OrderController {
 	public ResponseEntity<CommonResponse<OrderResponseDto>> readOrder(@PathVariable("orderId")UUID orderId) {
 		OrderResponseDto orderResponseDto = orderService.findOrder(orderId);
 		return ResponseEntity.ok().body(new CommonResponse<>(SuccessCode.ORDER_SEARCH_ONE, orderResponseDto));
+	}
+
+	// 주문 리스트 조회(전체, 허브별, 배송담당자별, 업체별) + 검색
+	@GetMapping
+	public ResponseEntity<CommonResponse<Page<OrderResponseDto>>> readOrders(
+		@RequestParam(required = false) String keyword,
+		@RequestParam(defaultValue = "0", required = false) int page,
+		@RequestParam(defaultValue = "10", required = false) int size,
+		@RequestParam(defaultValue = "DESC", required = false) Sort.Direction sortDirection,
+		@RequestParam(defaultValue = "UPDATED_AT", required = false) PageUtils.CommonSortBy sortBy,
+		@RequestHeader("X-User-Role") String userRole,
+		@RequestHeader("X-User-Id") UUID userId
+	) {
+		Page<OrderResponseDto> orders = orderService.findAllOrdersByRole(keyword, page, size, sortDirection, sortBy, userRole, userId);
+		return ResponseEntity.ok().body(new CommonResponse<>(SuccessCode.ORDER_SEARCH_ALL, orders));
 	}
 }

--- a/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/request/OrderRequestDto.java
+++ b/order-service/src/main/java/com/fn/eureka/client/orderservice/presentation/request/OrderRequestDto.java
@@ -1,4 +1,4 @@
-package com.fn.eureka.client.orderservice.presentation.dto;
+package com.fn.eureka.client.orderservice.presentation.request;
 
 import java.sql.Timestamp;
 import java.util.UUID;

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -28,6 +28,5 @@ eureka:
 
 logging:
   level:
-    com.fn.eureka.client.orderservice.infrastructure.CompanyServiceClient: DEBUG
     org.springframework.cloud.openfeign: DEBUG
     org.springframework.web.client.RestTemplate: DEBUG


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - Order SuccessCode 수정 및 OrderException 추가
    - OrderQueryRepository 추가로 전체/업체별 주문 리스트 조회 가능
    (추후 client 메서드 수정해 허브별/배송담당자별 추가 예정)
    - company-service에 아래와 같은 API 추가
    1. 허브ID가 같은 업체ID 리스트 조회
    2. 업체담당자ID로 업체ID 조회
    - DDD 구조로 패키지 재변경 (그런데 맞는지는 잘 모르겠음.)

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
